### PR TITLE
nvfuser_decomp_table

### DIFF
--- a/torchdynamo/optimizations/training.py
+++ b/torchdynamo/optimizations/training.py
@@ -271,7 +271,7 @@ def prims_executor(gm, inputs, *, executor):
     # First we trace the graph conditionally decomposing nodes
     # that may be sent to the nvfuser executor
     with TorchRefsNvfuserCapabilityMode():
-        prim_gm = make_fx(gm.__call__)(*inputs)
+        prim_gm = make_fx(gm.__call__, decomposition_table=torch._prims.context.nvfuser_decomp_table())(*inputs)
     t2 = time()
 
     # This function is called once per forward/backward pass of a graph in AOT


### PR DESCRIPTION
Works with https://github.com/pytorch/pytorch/pull/83782

Handles lowering of `_to_copy` (introduced by decomposition table) to `prims.convert_element_type`